### PR TITLE
fix(branding.desc): update boot entry name

### DIFF
--- a/branding.desc
+++ b/branding.desc
@@ -14,7 +14,7 @@ strings:
     shortVersion:        devel
     versionedName:       Rhino Linux
     shortVersionedName:  Rhino Linux
-    bootloaderEntryName: Ubuntu
+    bootloaderEntryName: Rhino
     productUrl:          https://rhinolinux.org/
     supportUrl:          https://rhinolinux.org/wiki/
     releaseNotesUrl:     https://rhinolinux.org/news/


### PR DESCRIPTION
Change` Ubuntu"` to `Rhino` for key `BootloaderEntryName` in [branding.desc](https://github.com/rhino-linux/calamares/commit/db320d48d8b3485fb8cb36fb6c38fe0317ff8b60).

First pull request ever, so go easy on me, haha.  It's entirely possible I _don't_ know what I'm talking about...but I noticed a bug reported for what I _think_ is something I had just noticed while poking around shortly after install.  May be old and not used any more, but I thought it might be helpful to find & fix it.  